### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/views/js/bootstrap.js
+++ b/views/js/bootstrap.js
@@ -148,7 +148,9 @@
       }
 
       try {
-        return document.querySelector(selector) ? selector : null;
+        // Ensure the selector is a valid CSS selector and not executable code
+        var sanitizedSelector = document.querySelector(selector) ? selector : null;
+        return sanitizedSelector && /^[.#]?[a-zA-Z0-9_-]+$/.test(sanitizedSelector) ? sanitizedSelector : null;
       } catch (err) {
         return null;
       }
@@ -1075,7 +1077,7 @@
           return;
         }
 
-        var target = $(selector)[0];
+        var target = document.querySelector(selector);
 
         if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
           return;


### PR DESCRIPTION
Potential fix for [https://github.com/mdawoud27/Readify/security/code-scanning/4](https://github.com/mdawoud27/Readify/security/code-scanning/4)

To fix the issue, we need to ensure that the `selector` is sanitized or validated before being used in jQuery. Instead of directly passing the `selector` to `$(selector)`, we can use a safer alternative like `$.find(selector)` or ensure the `selector` is strictly a valid CSS selector and not executable code. Additionally, we should ensure that the `data-target` attribute is not used to inject malicious content.

The changes will involve:
1. Modifying the `Util.getSelectorFromElement` function to ensure the `selector` is sanitized or validated.
2. Updating the usage of `Util.getSelectorFromElement` in the `Carousel._dataApiClickHandler` function to handle the sanitized `selector`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
